### PR TITLE
findKanjiNumbersで旧漢数字を抽出するよう修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,13 +59,13 @@ export function number2kanji(num: number) {
 }
 
 export function findKanjiNumbers(text: string) {
-  const basePattern = '([0-9０-９一二三四五六七八九]+千)?([0-9０-９一二三四五六七八九]*百)?([0-9０-９一二三四五六七八九]*十)?([0-9０-９〇一二三四五六七八九]+)?'
-  const pattern = `(${basePattern}兆)?(${basePattern}億)?(${basePattern}万)?${basePattern}`
+  const basePattern = '([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]+(千|阡|仟))?([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(百|陌|佰))?([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(十|拾))?([0-9０-９〇一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]+)?'
+  const pattern = `(${basePattern}兆)?(${basePattern}億)?(${basePattern}(万|萬))?${basePattern}`
   const regex = new RegExp(pattern, 'g')
   const match = text.match(regex)
   if (match) {
     return match.filter((item) => {
-      if (item.length && '兆' !== item && '億' !== item && '万' !== item) {
+      if (item.length && '兆' !== item && '億' !== item && '万' !== item && '萬' !== item) {
         return true
       } else {
         return false

--- a/test/test.ts
+++ b/test/test.ts
@@ -57,6 +57,12 @@ describe('Tests for japaneseNumeral.', () => {
     assert.deepEqual([ '２千20', '十一', '二十' ], findKanjiNumbers('今日は２千20年十一月二十日です。'))
   })
 
+  it('should find old Japanese Kanji numbers.', () => {
+    assert.deepEqual([ '壱', '弐' ], findKanjiNumbers('私が住んでいるのは壱番館の弐号室です。'))
+    assert.deepEqual([ '壱阡陌拾壱兆壱億壱萬壱阡', ], findKanjiNumbers('私は、壱阡陌拾壱兆壱億壱萬壱阡円持っています。'))
+    assert.deepEqual([ '壱仟佰拾壱兆壱億壱萬壱仟', ], findKanjiNumbers('私は、壱仟佰拾壱兆壱億壱萬壱仟円持っています。'))
+  })
+
   it('should convert mixed Japanese Kanji numbers to numbers.', () => {
     assert.deepEqual(kanji2number('100万'), 1000000)
     assert.deepEqual(kanji2number('5百'), 500)

--- a/test/test.ts
+++ b/test/test.ts
@@ -14,6 +14,8 @@ describe('Tests for japaneseNumeral.', () => {
     assert.deepEqual(kanji2number('二千'), 2000)
     assert.deepEqual(kanji2number('壱万'), 10000)
     assert.deepEqual(kanji2number('一二三四'), 1234)
+    assert.deepEqual(kanji2number('壱阡陌拾壱兆壱阡陌拾壱億壱阡陌拾壱萬壱阡陌拾壱'), 1111111111111111)
+    assert.deepEqual(kanji2number('壱仟佰拾壱兆壱仟佰拾壱億壱仟佰拾壱萬壱仟佰拾壱'), 1111111111111111)
   });
 
   it('Number should be converted to Japanese kanji', () => {
@@ -59,8 +61,8 @@ describe('Tests for japaneseNumeral.', () => {
 
   it('should find old Japanese Kanji numbers.', () => {
     assert.deepEqual([ '壱', '弐' ], findKanjiNumbers('私が住んでいるのは壱番館の弐号室です。'))
-    assert.deepEqual([ '壱阡陌拾壱兆壱億壱萬壱阡', ], findKanjiNumbers('私は、壱阡陌拾壱兆壱億壱萬壱阡円持っています。'))
-    assert.deepEqual([ '壱仟佰拾壱兆壱億壱萬壱仟', ], findKanjiNumbers('私は、壱仟佰拾壱兆壱億壱萬壱仟円持っています。'))
+    assert.deepEqual([ '壱阡陌拾壱兆壱億壱萬', ], findKanjiNumbers('私は、壱阡陌拾壱兆壱億壱萬円持っています。'))
+    assert.deepEqual([ '壱仟佰拾壱兆壱億壱萬', ], findKanjiNumbers('私は、壱仟佰拾壱兆壱億壱萬円持っています。'))
   })
 
   it('should convert mixed Japanese Kanji numbers to numbers.', () => {


### PR DESCRIPTION
Fix #7 