### PR TITLE
Update index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function number2kanji(num: number) {
 }
 
 export function findKanjiNumbers(text: string) {
-  const basePattern = '([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]+(千|阡|仟))?([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(百|陌|佰))?([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(十|拾))?([0-9０-９〇一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]+)?'
+  const basePattern = '([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(千|阡|仟))?([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(百|陌|佰))?([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(十|拾))?([0-9０-９〇一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]+)?'
   const pattern = `(${basePattern}兆)?(${basePattern}億)?(${basePattern}(万|萬))?${basePattern}`
   const regex = new RegExp(pattern, 'g')
   const match = text.match(regex)


### PR DESCRIPTION
「千百十一兆千百十一億千百十一万千百十一」のパターンにて途中で分割されてしまう。
「一千百十一兆一千百十一億一千百十一万一千百十一」では分割されない。

百や十の桁と同様にアスタリスクが正しいと思います。