### PR TITLE
Bug fix to find mixed japanese kanji numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,13 +59,14 @@ export function number2kanji(num: number) {
 }
 
 export function findKanjiNumbers(text: string) {
-  const basePattern = '([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(千|阡|仟))?([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(百|陌|佰))?([0-9０-９一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*(十|拾))?([0-9０-９〇一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]+)?'
-  const pattern = `(${basePattern}兆)?(${basePattern}億)?(${basePattern}(万|萬))?${basePattern}`
+  const num = '([0-9０-９]*)|([〇一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*)'
+  const basePattern = `((${num})(千|阡|仟))?((${num})(百|陌|佰))?((${num})(十|拾))?(${num})?`
+  const pattern = `((${basePattern}兆)?(${basePattern}億)?(${basePattern}(万|萬))?${basePattern})`
   const regex = new RegExp(pattern, 'g')
   const match = text.match(regex)
   if (match) {
     return match.filter((item) => {
-      if (item.length && '兆' !== item && '億' !== item && '万' !== item && '萬' !== item) {
+      if ((! item.match(/^[0-9０-９]+$/)) && (item.length && '兆' !== item && '億' !== item && '万' !== item && '萬' !== item)) {
         return true
       } else {
         return false

--- a/test/test.ts
+++ b/test/test.ts
@@ -46,8 +46,9 @@ describe('Tests for japaneseNumeral.', () => {
     assert.deepEqual([ '八百六十三' ], findKanjiNumbers('今日のランチは八百六十三円でした。'))
     assert.deepEqual([ '八六三' ], findKanjiNumbers('今日のランチは八六三円でした。'))
     assert.deepEqual([ '三千' ], findKanjiNumbers('今月のお小遣いは三千円です。'))
-    assert.deepEqual([ '五', '千', '６２', '８' ], findKanjiNumbers('青森県五所川原市金木町喜良市千苅６２−８'))
+    assert.deepEqual([ '五', '千' ], findKanjiNumbers('青森県五所川原市金木町喜良市千苅６２−８'))
     assert.deepEqual([ '1億2000万' ], findKanjiNumbers('わたしは1億2000万円もっています。'))
+    assert.deepEqual([ '六' ], findKanjiNumbers('香川県仲多度郡まんのう町勝浦字家六２０９４番地１'))
   })
 
   it('should not find Japanese Kanji numbers.', () => {
@@ -96,3 +97,12 @@ describe('Tests for japaneseNumeral.', () => {
     assert.deepEqual(kanji2number('１２３'), 123)
   })
 });
+
+// https://github.com/geolonia/normalize-japanese-addresses/issues/94
+it('should find Japanese Kanji number `六` in `香川県仲多度郡まんのう町勝浦字家六２０９４番地１`.', () => {
+  assert.deepEqual([ '六' ], findKanjiNumbers('香川県仲多度郡まんのう町勝浦字家六２０９４番地１'))
+})
+
+it('should find Japanese Kanji number in `今日は２千20年十一月二十日です。`.', () => {
+  assert.deepEqual([ '２千20', '十一', '二十' ], findKanjiNumbers('今日は２千20年十一月二十日です。'))
+})


### PR DESCRIPTION
Related: https://github.com/geolonia/normalize-japanese-addresses/issues/94