### PR TITLE
旧字体 「弍」を追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function number2kanji(num: number) {
 }
 
 export function findKanjiNumbers(text: string) {
-  const num = '([0-9０-９]*)|([〇一二三四五六七八九壱壹弐貳貮参參肆伍陸漆捌玖]*)'
+  const num = '([0-9０-９]*)|([〇一二三四五六七八九壱壹弐弍貳貮参參肆伍陸漆捌玖]*)'
   const basePattern = `((${num})(千|阡|仟))?((${num})(百|陌|佰))?((${num})(十|拾))?(${num})?`
   const pattern = `((${basePattern}兆)?(${basePattern}億)?(${basePattern}(万|萬))?${basePattern})`
   const regex = new RegExp(pattern, 'g')

--- a/src/oldJapaneseNumerics.ts
+++ b/src/oldJapaneseNumerics.ts
@@ -7,6 +7,7 @@ const oldJapaneseNumerics: oldJapaneseNumericsType = {
   壱: '一',
   壹: '一',
   弐: '二',
+  弍: '二',
   貳: '二',
   貮: '二',
   参: '三',

--- a/test/test.ts
+++ b/test/test.ts
@@ -13,6 +13,7 @@ describe('Tests for japaneseNumeral.', () => {
     assert.deepEqual(kanji2number('二〇二〇'), 2020)
     assert.deepEqual(kanji2number('二千'), 2000)
     assert.deepEqual(kanji2number('壱万'), 10000)
+    assert.deepEqual(kanji2number('弍万'), 20000)
     assert.deepEqual(kanji2number('一二三四'), 1234)
     assert.deepEqual(kanji2number('壱阡陌拾壱兆壱阡陌拾壱億壱阡陌拾壱萬壱阡陌拾壱'), 1111111111111111)
     assert.deepEqual(kanji2number('壱仟佰拾壱兆壱仟佰拾壱億壱仟佰拾壱萬壱仟佰拾壱'), 1111111111111111)
@@ -62,6 +63,7 @@ describe('Tests for japaneseNumeral.', () => {
 
   it('should find old Japanese Kanji numbers.', () => {
     assert.deepEqual([ '壱', '弐' ], findKanjiNumbers('私が住んでいるのは壱番館の弐号室です。'))
+    assert.deepEqual([ '弍' ], findKanjiNumbers('私は、ハイツ弍号棟に住んでいます。'))
     assert.deepEqual([ '壱阡陌拾壱兆壱億壱萬', ], findKanjiNumbers('私は、壱阡陌拾壱兆壱億壱萬円持っています。'))
     assert.deepEqual([ '壱仟佰拾壱兆壱億壱萬', ], findKanjiNumbers('私は、壱仟佰拾壱兆壱億壱萬円持っています。'))
   })


### PR DESCRIPTION
今まで、`弐` はありましたが、`弍` がなかったので追加しました。

https://ja.wiktionary.org/wiki/%E5%BC%8D