### PR TITLE
revert 350 problem

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,6 @@ import japaneseNumerics from './japaneseNumerics'
 export function kanji2number(japanese: string) {
   japanese = normalize(japanese)
 
-  // 末尾の十は〇と同等なので一旦それに正規化
-  japanese = japanese.replace(/(.+)(十)$/, '$1〇');
-
   if (japanese.match('〇') || japanese.match(/^[〇一二三四五六七八九]+$/)) {
     for (const key in japaneseNumerics) {
       const reg = new RegExp(key, 'g')

--- a/test/test.ts
+++ b/test/test.ts
@@ -9,7 +9,6 @@ describe('Tests for japaneseNumeral.', () => {
     assert.deepEqual(kanji2number('百十一'), 111)
     assert.deepEqual(kanji2number('三億八'), 300000008)
     assert.deepEqual(kanji2number('三百八'), 308)
-    assert.deepEqual(kanji2number('三五十'), 350)
     assert.deepEqual(kanji2number('三五〇'), 350)
     assert.deepEqual(kanji2number('三〇八'), 308)
     assert.deepEqual(kanji2number('二〇二〇'), 2020)
@@ -43,6 +42,7 @@ describe('Tests for japaneseNumeral.', () => {
 
     // @ts-ignore
     assert.throws(() => kanji2number('あ'), TypeError)
+    assert.throws(() => kanji2number('三五十'), TypeError)
   });
 
   it('should find Japanese Kanji numbers.', () => {
@@ -113,8 +113,4 @@ it('should find Japanese Kanji number `六` in `香川県仲多度郡まんの�
 
 it('should find Japanese Kanji number in `今日は２千20年十一月二十日です。`.', () => {
   assert.deepEqual([ '２千20', '十一', '二十' ], findKanjiNumbers('今日は２千20年十一月二十日です。'))
-})
-
-it('should work with format like 三五十', () => {
-  assert.deepEqual(['三五十'], findKanjiNumbers('愛知県豊田市西丹波町三五十'))
 })

--- a/test/test.ts
+++ b/test/test.ts
@@ -37,10 +37,7 @@ describe('Tests for japaneseNumeral.', () => {
     // @ts-ignore
     assert.throws(() => number2kanji('hello'), TypeError)
 
-    // @ts-ignore
     assert.throws(() => kanji2number('三あ八'), TypeError)
-
-    // @ts-ignore
     assert.throws(() => kanji2number('あ'), TypeError)
     assert.throws(() => kanji2number('三五十'), TypeError)
   });


### PR DESCRIPTION
#15 について、`三五十` は `350` に正規化されるべきと考えてました。しかし、漢数字の表現方法として用例をあまり見つけることができなかったため、リバートしたいと考えています。

さらに、元の issue (https://github.com/geolonia/normalize-japanese-addresses/issues/215) についても、コメントをいただいた @mimidesunya さんが、対象の住所 `愛知県豊田市西丹波町三五十` のうちの `三五十` が小字である旨を書いていただいていたにも関わらず、 私が見逃してしまっていて `三五十` が 「350番地」だと思い込んでしまっていたこともこのリバートの作業が発生した理由になります。