### PR TITLE
0 should be transformed as 〇 with number2kanji function fix #17

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export function number2kanji(num: number) {
     kanji = `${kanji}${n2kan(number)}`
   }
 
-  return kanji
+  return kanji || '〇'
 }
 
 export function findKanjiNumbers(text: string) {

--- a/test/test.ts
+++ b/test/test.ts
@@ -3,6 +3,8 @@ import { assert } from 'chai'
 
 describe('Tests for japaneseNumeral.', () => {
   it('Japanese numeric should be parsed as numbers.', () => {
+    assert.deepEqual(kanji2number('〇'), 0)
+    assert.deepEqual(kanji2number('零'), 0)
     assert.deepEqual(kanji2number('一千百十一兆一千百十一億一千百十一万一千百十一'), 1111111111111111)
     assert.deepEqual(kanji2number('一千百十一兆一千百十一億一千百十一万'), 1111111111110000)
     assert.deepEqual(kanji2number('一千百十一兆一千百十一億一千百十一'), 1111111100001111)
@@ -25,6 +27,8 @@ describe('Tests for japaneseNumeral.', () => {
   });
 
   it('Number should be converted to Japanese kanji', () => {
+    assert.deepEqual(number2kanji(0), '〇')
+    assert.deepEqual(number2kanji(1110), '千百十')
     assert.deepEqual(number2kanji(1111111111111111), '千百十一兆千百十一億千百十一万千百十一')
     assert.deepEqual(number2kanji(1111113111111111), '千百十一兆千百三十一億千百十一万千百十一')
     assert.deepEqual(number2kanji(1000000000000000), '千兆')


### PR DESCRIPTION
@geolonia/normalize-japanese-addresses が本ライブラリに依存していますが、この内容のアップデートを行った時にテストが変わらず成功することを確認済みです。