### PR TITLE
findKanjiNumbers が漢数字「零」を抽出しない不具合を修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function number2kanji(num: number) {
 }
 
 export function findKanjiNumbers(text: string) {
-  const num = '([0-9０-９]*)|([〇零一二三四五六七八九壱壹弐弍貳貮参參肆伍陸漆捌玖]*)'
+  const num = '([0-9０-９]*)|([〇一二三四五六七八九零壱壹弐弍貳貮参參肆伍陸漆捌玖]*)'
   const basePattern = `((${num})(千|阡|仟))?((${num})(百|陌|佰))?((${num})(十|拾))?(${num})?`
   const pattern = `((${basePattern}兆)?(${basePattern}億)?(${basePattern}(万|萬))?${basePattern})`
   const regex = new RegExp(pattern, 'g')

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function number2kanji(num: number) {
 }
 
 export function findKanjiNumbers(text: string) {
-  const num = '([0-9０-９]*)|([〇一二三四五六七八九壱壹弐弍貳貮参參肆伍陸漆捌玖]*)'
+  const num = '([0-9０-９]*)|([〇零一二三四五六七八九壱壹弐弍貳貮参參肆伍陸漆捌玖]*)'
   const basePattern = `((${num})(千|阡|仟))?((${num})(百|陌|佰))?((${num})(十|拾))?(${num})?`
   const pattern = `((${basePattern}兆)?(${basePattern}億)?(${basePattern}(万|萬))?${basePattern})`
   const regex = new RegExp(pattern, 'g')

--- a/test/test.ts
+++ b/test/test.ts
@@ -69,6 +69,7 @@ describe('Tests for japaneseNumeral.', () => {
   })
 
   it('should find old Japanese Kanji numbers.', () => {
+    assert.deepEqual([ '零' ], findKanjiNumbers('口座の残高は零円です。'))
     assert.deepEqual([ '壱', '弐' ], findKanjiNumbers('私が住んでいるのは壱番館の弐号室です。'))
     assert.deepEqual([ '弍' ], findKanjiNumbers('私は、ハイツ弍号棟に住んでいます。'))
     assert.deepEqual([ '壱阡陌拾壱兆壱億壱萬', ], findKanjiNumbers('私は、壱阡陌拾壱兆壱億壱萬円持っています。'))


### PR DESCRIPTION
## 概要

`findKanjiNumbers` が漢数字の「零」を抽出できません。同じゼロを表す「〇」や大字（壱壹弐弍…玖）はすべて文字クラスに入っているのに、「零」だけ漏れていました。

## 詳細

このライブラリは「零」を数字として扱っています。`oldJapaneseNumerics` に `零: '〇'` の定義があり、`kanji2number('零')` も 0 を返します（既存テストで確認済み）。

ところが `findKanjiNumbers` の文字クラスは

```
([0-9０-９]*)|([〇一二三四五六七八九壱壹弐弍貳貮参參肆伍陸漆捌玖]*)
```

となっていて、「〇」と大字は含むのに「零」が入っていません。結果として、同じゼロでも片方しか拾えない状態になっています。

```js
findKanjiNumbers('口座の残高は零円です。') // 現状: []  （期待値: ['零']）
findKanjiNumbers('〇円')                   // ['〇']
```

## 修正

文字クラスの「〇」の隣に「零」を追加しました。テストを1件足しています（修正前は `['零']` の代わりに `[]` が返り fail します）。既存テストはすべてパスしたままです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 漢数字の「零」を数値候補として認識できるようになりました。
  * 文中に含まれる「零」を旧漢数字として正しく検出できるようになりました。
* **Tests**
  * 「零」を検出できることを確認するテストケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->